### PR TITLE
added ecr for pipeline

### DIFF
--- a/terraform/pipeline_ecr.tf
+++ b/terraform/pipeline_ecr.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "c14_trendgineers_pipeline_ecr" {
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  image_tag_mutability = "MUTABLE"
+  name                 = "c14-trendgineers-pipeline-ecr"
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+


### PR DESCRIPTION
We now have an ecr called c14-trendgineers-pipeline-ecr.
This ECR has been created to store the pipeline image.