### PR TITLE
Updating keyword data notifications

### DIFF
--- a/terraform/eventbridge_update_step_function.tf
+++ b/terraform/eventbridge_update_step_function.tf
@@ -1,0 +1,56 @@
+data "aws_sfn_state_machine" "my_state_machine" {
+  name = "MyStateMachine-3czm3doz8"
+}
+
+resource "aws_cloudwatch_event_rule" "step_function_schedule_rule" {
+  name                = "c14-trendgineers-hourly-step-function-schedule"
+  description         = "Runs the Step Function MyStateMachine-3czm3doz8 every day at 6 PM"
+  schedule_expression = "cron(0 * * * ? *)" # Cron for on each hour
+}
+
+resource "aws_iam_role" "eventbridge_step_function_role" {
+  name = "EventBridgeStepFunctionRole"
+
+  assume_role_policy = jsonencode({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: {
+          Service: "events.amazonaws.com"
+        },
+        Action: "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "eventbridge_step_function_policy" {
+  role = aws_iam_role.eventbridge_step_function_role.name
+
+  policy = jsonencode({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "states:StartExecution",
+        Resource: data.aws_sfn_state_machine.my_state_machine.arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "step_function_target" {
+  rule      = aws_cloudwatch_event_rule.step_function_schedule_rule.name
+  target_id = "step-function-daily-target"
+  arn       = data.aws_sfn_state_machine.my_state_machine.arn
+
+  # Optional: Pass input to the Step Function
+  input = jsonencode({
+    "TriggerSource": "EventBridge",
+    "ExecutionTime": "${timestamp()}"
+  })
+
+  # IAM role for EventBridge to invoke the Step Function
+  role_arn = aws_iam_role.eventbridge_step_function_role.arn
+}

--- a/terraform/keyword_notification_update_ecr.tf
+++ b/terraform/keyword_notification_update_ecr.tf
@@ -1,0 +1,15 @@
+resource "aws_ecr_repository" "c14_trendgineers_update_for_notifications_ecr" {
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  image_tag_mutability = "MUTABLE"
+  name                 = "c14-trendgineers-update-for-notifications-ecr"
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/terraform/keyword_notification_update_ecs.tf
+++ b/terraform/keyword_notification_update_ecs.tf
@@ -1,0 +1,157 @@
+resource "aws_iam_role" "update_notifications_ecs_service_role" {
+  name               = "c14-trendgineers-update-notifications-ecs-service-role"
+  lifecycle {
+    prevent_destroy = false
+  }
+  assume_role_policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect    : "Allow",
+        Principal : {
+          Service : "ecs-tasks.amazonaws.com"
+        },
+        Action    : "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "update_notifications_ecs_service_rds_policy" {
+  name        = "c14-trendgineers-update-notifications-ecs-service-rds-policy"
+  description = "Grant ECS service permissions to interact with the RDS database for reading and writing data."
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect   : "Allow",
+        Action   : [
+          "rds:DescribeDBInstances"
+        ],
+        Resource : [
+            "arn:aws:rds:eu-west-2:129033205317:db:c14-trend-getter-db"
+        ]
+      },
+      # Allow ECS tasks to read from the specified S3 bucket
+      {
+        Effect   : "Allow",
+        Action   : [
+          "s3:GetObject",     
+          "s3:ListBucket"      
+        ],
+        Resource : [
+          "arn:aws:s3:::trendgineers-raw-firehose-data",      
+          "arn:aws:s3:::trendgineers-raw-firehose-data/*"     
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "update_notifications_ecs_service_s3_policy_attachment" {
+  role       = aws_iam_role.update_notifications_ecs_service_role.name
+  policy_arn = aws_iam_policy.update_notifications_ecs_service_rds_policy.arn
+}
+
+resource "aws_cloudwatch_log_group" "update_notifications_log_group" {
+  name              = "/ecs/c14-trendgineers-update-notifications"
+  lifecycle {
+    prevent_destroy = false
+  }
+  retention_in_days = 7
+}
+
+resource "aws_ecs_task_definition" "c14_trendgineers_update_notifications" {
+  family                   = "c14-trendgineers-update-notifications"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "1024"
+  task_role_arn            = aws_iam_role.update_notifications_ecs_service_role.arn # keep
+  execution_role_arn       = data.aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "c14-trendgineers-update-notifications" 
+      image       = "http://129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14-trendgineers-update-for-notifications-ecr:latest"
+      cpu         = 256
+      memory      = 512
+      essential   = true
+      
+      environment = [
+        { name = "DB_HOST", value = var.DB_HOST },
+        { name = "DB_PORT", value = var.DB_PORT },
+        { name = "DB_USERNAME", value = var.DB_USERNAME },
+        { name = "SCHEMA_NAME", value = var.SCHEMA_NAME },
+        { name = "DB_NAME", value = var.DB_NAME },
+        { name = "DB_PASSWORD", value = var.DB_PASSWORD },
+        { name = "AWS_ACCESS_KEY_ID", value = var.ACCESS_KEY_ID },
+        { name = "AWS_SECRET_ACCESS_KEY", value = var.SECRET_ACCESS_KEY }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-create-group  = "true"
+          awslogs-group         = "/ecs/c14-trendgineers-update-notifications"
+          awslogs-region        = "eu-west-2"
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  runtime_platform {
+    cpu_architecture       = "X86_64"
+    operating_system_family = "LINUX"
+  }
+}
+
+resource "aws_security_group" "update_notifications_ecs_service_sg" {
+  name        = "c14-trendgineers-update-notifications-sg"
+  description = "Allow ECS tasks to read data from S3 and upload to RDS"
+  vpc_id      = var.VPC_ID
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] 
+  }
+
+  ingress {
+    from_port   = 5000
+    to_port     = 5000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] 
+  }
+
+  # Egress rule for S3 (HTTPS)
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] 
+  }
+
+  # Egress rule for RDS
+  egress {
+    from_port   = 5432 # Replace with your RDS port if different
+    to_port     = 5432
+    protocol    = "tcp"
+    security_groups = [aws_security_group.rds_sg.id] 
+  }
+
+  tags = {
+    Name = "update notifications ECS Service SG"
+  }
+}
+

--- a/terraform/notifications_lambda.tf
+++ b/terraform/notifications_lambda.tf
@@ -91,25 +91,4 @@ resource "aws_lambda_function" "notifications_lambda" {
 
 }
 
-# EventBridge Rule for Hourly Schedule
-resource "aws_cloudwatch_event_rule" "notifications_schedule_rule" {
-  name                = "notifications_lambda_schedule_hourly"
-  description         = "Runs the notifications Lambda every hour"
-  schedule_expression = "rate(1 hour)"  # Every hour
-}
 
-# Lambda Permission for EventBridge Rule
-resource "aws_lambda_permission" "notifications_allow_eventbridge" {
-  statement_id  = "AllowExecutionFromEventBridgeHourly"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.notifications_lambda.function_name
-  principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.notifications_schedule_rule.arn
-}
-
-# EventBridge Target for Lambda
-resource "aws_cloudwatch_event_target" "notifications_lambda_target" {
-  rule      = aws_cloudwatch_event_rule.notifications_schedule_rule.name
-  target_id = "notifications-lambda-hourly-target"
-  arn       = aws_lambda_function.notifications_lambda.arn
-}


### PR DESCRIPTION
I created the AWS resources needed to host the keyword data update script on the cloud. This included an ECR, an ECS task definition alongside roles, policies, security and cloud watch groups. I also created a step function to call this script and then send the updated notifications to our subscribers.